### PR TITLE
Update cat timer for 6-18 shift

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ If you prefer a calmer look with a gentle pink background and white digits, run:
 python cat_timer.py
 ```
 
-This alternative timer keeps the cute pixel cat but uses softer colors. The cat
-now blinks and is drawn with more detail along with additional pixel art (a
-heart and a ball of yarn). You can change the end-of-day time with the small
-input fields under the timer.
+This alternative timer keeps the cute pixel cat but uses softer colors. It now
+counts down to the end of a 6:00–18:00 shift by default and shows the cat at the
+bottom of the window. The cat blinks and is drawn with more detail along with
+additional pixel art (a heart and a ball of yarn). You can change the
+end-of-day time with the small input fields under the timer.

--- a/cat_timer.py
+++ b/cat_timer.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from PIL import Image, ImageDraw, ImageTk
 
 # Default end time for the workday
-END_HOUR = 17
+END_HOUR = 18
 END_MINUTE = 0
 
 blink_state = 0
@@ -108,9 +108,6 @@ root.configure(bg="#FFB6C1")  # light pink
 cat_images = [create_cat_image(False), create_cat_image(True)]
 heart_image = create_heart_image()
 yarn_image = create_yarn_image()
-cat_label = tk.Label(root, image=cat_images[0], bg="#FFB6C1")
-cat_label.pack(pady=5)
-
 timer_label = tk.Label(
     root, text="", font=("Arial", 40, "bold"), bg="#FFB6C1", fg="white"
 )
@@ -132,6 +129,9 @@ heart_label = tk.Label(root, image=heart_image, bg="#FFB6C1")
 heart_label.pack(pady=5)
 yarn_label = tk.Label(root, image=yarn_image, bg="#FFB6C1")
 yarn_label.pack(pady=5)
+
+cat_label = tk.Label(root, image=cat_images[0], bg="#FFB6C1")
+cat_label.pack(pady=5)
 
 update_timer()
 root.mainloop()


### PR DESCRIPTION
## Summary
- modify cat timer's default end of workday to 18:00
- place the cat graphic at the bottom of the window
- document the new 6:00–18:00 shift countdown in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fe594b60c8326b883f68f8ec90b3c